### PR TITLE
ci: add GitHub Actions workflow for todotxt.nvim tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Neovim ${{ matrix.neovim }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        neovim: [v0.9.5, v0.10.3, nightly]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - name: Setup Neovim ${{ matrix.neovim }}
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: ${{ matrix.neovim }}
+
+      - name: Show versions
+        run: |
+          which nvim
+          nvim --version
+          just --version || true
+
+      - name: Install just
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
+
+      - name: Install mini.nvim test dependency
+        run: |
+          mkdir -p deps/pack/deps/start
+          cd deps/pack/deps/start
+          git clone --depth=1 https://github.com/echasnovski/mini.nvim.git
+
+      - name: Run tests
+        env:
+          TERM: xterm
+        run: |
+          just test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Comprehensive test coverage for hierarchical project functionality
   - Backward compatible with existing flat project syntax (`+project`)
   - Tasks can contain both flat (`+work`) and hierarchical (`+work-meeting`) projects
-  - Project operations (completion toggle, priority cycling) preserve hierarchical project tokens
+- Project operations (completion toggle, priority cycling) preserve hierarchical project tokens
+
+### Fixed
+- **File Creation Error**: Fixed "File exists" error when saving new `todo.txt` files (issue #8)
+  - Root cause: Buffer-local `BufWriteCmd` autocmds from floating windows could persist and interfere with normal file editing
+  - Solution: Redesigned save interception to be strictly scoped to floating buffers with proper cleanup
+  - Added robust file creation support with atomic saves (temp file + rename)
+  - Enhanced save handler supports creating files in non-existent directories
+  - Comprehensive test coverage for both floating and normal editing contexts
+  - Ensures save interception is limited to floating window context only
 
 ### Changed
 - Updated project pattern in `patterns.lua` to support dash separators in project names

--- a/lua/todotxt/utils.lua
+++ b/lua/todotxt/utils.lua
@@ -229,7 +229,7 @@ end
 --- Handles saving for floating buffers with proper file creation support.
 --- This function is called by the buffer-local BufWriteCmd autocmd created for floating windows.
 --- It provides robust file creation, atomic saves, and proper hidden task merging.
---- 
+---
 --- Key features:
 --- - Supports creating new files and directories
 --- - Uses atomic save (temp file + rename) for safety


### PR DESCRIPTION
This adds a CI workflow that runs the MiniTest suite via 'just test' on Neovim v0.9, v0.10, and nightly. It installs 'just', clones mini.nvim into deps/pack/deps/start/mini.nvim, and runs headless tests using scripts/minimal_init.lua.

The workflow:
- Tests on multiple Neovim versions: v0.9.5, v0.10.3, and nightly
- Installs 'just' command runner
- Clones mini.nvim test dependency (since deps/ is gitignored)
- Runs the existing 'just test' command which uses MiniTest framework
- Uses concurrency controls to cancel previous runs on new pushes